### PR TITLE
Update soliscloud_api.py

### DIFF
--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -361,7 +361,7 @@ class SoliscloudAPI(BaseAPI):
 
             # Just temporary till SolisCloud is fixed
             self._data[GRID_DAILY_ON_GRID_ENERGY] = \
-                float(self._data[GRID_DAILY_ON_GRID_ENERGY])*10
+                float(self._data[GRID_DAILY_ON_GRID_ENERGY])
 
             # Unused phases are still in JSON payload as 0.0, remove them
             # FIXME: use acOutputType


### PR DESCRIPTION
Seems that Soliscloud may have corrected their issue.  Yesterday about midday BST my home assistant started reading grid energy as 10x what it should be.  I have updated code and it is now showing correctly.  