### PR TITLE
sync scraping to the API update schedule if possible to improve "freshness"

### DIFF
--- a/custom_components/solis/sensor.py
+++ b/custom_components/solis/sensor.py
@@ -6,7 +6,7 @@ For more information: https://github.com/hultenvp/solis-sensor/
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 import voluptuous as vol
@@ -148,7 +148,7 @@ def on_discovered(capabilities, cookie):
     hass_sensors = create_sensors(discovered_sensors, cookie['service'], cookie['name'])
     cookie['async_add_entities'](hass_sensors)
     # schedule the first update in 1 minute from now:
-    cookie['service'].schedule_update(1)
+    cookie['service'].schedule_update(timedelta(minutes=1))
 
 class SolisSensor(ServiceSubscriber, SensorEntity):
     """ Representation of a Solis sensor. """
@@ -176,7 +176,7 @@ class SolisSensor(ServiceSubscriber, SensorEntity):
 
     def do_update(self, value: Any, last_updated: datetime) -> bool:
         """ Update the sensor."""
-        if self.hass and self._attr_native_value != value:
+        if self.hass:
             self._attr_native_value = value
             self._attributes[LAST_UPDATED] = last_updated
             self.async_write_ha_state()


### PR DESCRIPTION
By using the "last update" field on the API output, and synchronizing to that plus our expected update schedule, we can record data from the API in HA as soon as possible after it's been recorded, maximising the data "freshness". If anything goes wrong with that, it'll fall back to just updating with a 5-minute period.