### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/solis/manifest.json
+++ b/custom_components/solis/manifest.json
@@ -9,6 +9,6 @@
   "dependencies": [],
   "codeowners": ["@hultenvp"],
   "requirements": [
-    "aiofiles>=23.1.0,<24.0.0"
+    "aiofiles>=23.1.0,<25.0.0"
   ]
 }


### PR DESCRIPTION
This fixes #399 for me.

After these changes my logs look normal again:
```
2024-12-04 17:26:48.597 INFO (MainThread) [homeassistant.setup] Setting up solis
2024-12-04 17:26:48.597 INFO (MainThread) [homeassistant.setup] Setup of domain solis took 0.00 seconds
2024-12-04 17:26:51.290 INFO (MainThread) [homeassistant.components.sensor] Setting up solis.sensor
2024-12-04 17:26:51.290 INFO (MainThread) [custom_components.solis.sensor] Scheduling discovery
2024-12-04 17:26:54.117 INFO (MainThread) [custom_components.solis.soliscloud_api] Login successful
```

Not sure if there was a good reason for the restriction, but it works for me.