### PR TITLE
Fix type comparison for JSON response codes in SoliscloudAPI

### DIFF
--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -788,9 +788,9 @@ class SoliscloudAPI(BaseAPI):
 
         if result[SUCCESS] is True:
             jsondata = result[CONTENT]
-            if jsondata["code"] == "0":
+            if str(jsondata["code"]) == "0":
                 jsondata = jsondata["data"][0]
-                if jsondata["code"] == "0":
+                if str(jsondata["code"]) == "0":
                     _LOGGER.debug(f"Set code returned OK. Reading code back.")
                     await asyncio.sleep(CONTROL_DELAY)
                     control_data = await self.get_control_data(device_serial, cid=str(cid))


### PR DESCRIPTION
Explicit casting for proper handling the following Solis Cloud API response:

```
{'Success': True, 'Message': 'OK', 'StatusCode': 200, 'Content': {'code': '0', 'data': [{'msg': 'bla bla', 'code': 0}], 'time': '1742420108429'}}
```

I decided to cast both "code" fields, a.k.a defensive programming 😀