### PR TITLE
Reduce polling back down to once every 5 minutes in control mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,4 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
-
-# Control Beta Test
-
-This repo includes a beta version of device control using the same API as the SolisCloud app. This operates slighty differently depending on your HMI firmware version. This should be detected automatically.
-
-Please report any issues via https://github.com/fboundy/solis-sensor/issues
-
-## Version 4A00 and Earlier
-
-The following controls should update the inverter immediately:
-
-- Energy Storage Control Switch
-- Overdischarge SOC
-- Force Charge SOC
-- Backup SOC
-
-The timed change controls are all sent to the API using one command and so they won't update untill the Update Charge/Discharge button is pressed. The controls included in this are all three sets of the following (where N is slots 1-3):
-
-- Timed Charge Current N
-- Timed Charge Start Time N
-- Timed Charge End Time N
-- Timed Discharge Current N
-- Timed Discharge Start Time N
-- Timed Discharge End Time N
-
-<b>Note that all three slots are sent at the same time</b>
-
-## Version 4B00 and Later
-
-Six slots are available and include an SOC limit and a voltage (though the purpose of the voltage is not clear). Only the start and end times for each Charge/Discharge slot need to to be sent to the inverter together so the following are updated immediately (where N is slot 1-6):
-
-- Energy Storage Control Switch (fewer available modes than pre-4B00)
-- Overdischarge SOC
-- Force Charge SOC
-- Backup SOC
-- Timed Charge Current N
-- Timed Charge SOC N
-- Timed Charge Voltage N
-- Timed Discharge Current N
-- Timed Discharge SOC N
-- Timed Discharge Voltage N
-
-Each pair of start/end times has an associated button push; for charge (where N is slot 1-6):
-
-- Timed Charge Start Time N
-- Timed Charge End Time N
-- Button Update Charge Time N
-
-And discharge:
-
-- Timed Discharge Start Time N
-- Timed Discharge End Time N
-- Button Update Discharge Time N
-
 # SolisCloud sensor integration
 
 HomeAssistant sensor for SolisCloud portal. 
@@ -166,6 +112,60 @@ The Solis integration now supports the energy dashboard introduced in Release 20
 
 ![dashboard integration](./image/energy_dashboard_integration.GIF)
 ![energy production](./image/solar_production_energy_dashboard.GIF)
+
+# Control Beta Test
+
+This includes a beta version of device control using the same API as the SolisCloud app, for use with inverters with an attached battery. This operates slighty differently depending on your HMI firmware version. This should be detected automatically.
+
+Please report any issues via https://github.com/fboundy/solis-sensor/issues
+
+## Version 4A00 and Earlier
+
+The following controls should update the inverter immediately:
+
+- Energy Storage Control Switch
+- Overdischarge SOC
+- Force Charge SOC
+- Backup SOC
+
+The timed change controls are all sent to the API using one command and so they won't update untill the Update Charge/Discharge button is pressed. The controls included in this are all three sets of the following (where N is slots 1-3):
+
+- Timed Charge Current N
+- Timed Charge Start Time N
+- Timed Charge End Time N
+- Timed Discharge Current N
+- Timed Discharge Start Time N
+- Timed Discharge End Time N
+
+<b>Note that all three slots are sent at the same time</b>
+
+## Version 4B00 and Later
+
+Six slots are available and include an SOC limit and a voltage (though the purpose of the voltage is not clear). Only the start and end times for each Charge/Discharge slot need to to be sent to the inverter together so the following are updated immediately (where N is slot 1-6):
+
+- Energy Storage Control Switch (fewer available modes than pre-4B00)
+- Overdischarge SOC
+- Force Charge SOC
+- Backup SOC
+- Timed Charge Current N
+- Timed Charge SOC N
+- Timed Charge Voltage N
+- Timed Discharge Current N
+- Timed Discharge SOC N
+- Timed Discharge Voltage N
+
+Each pair of start/end times has an associated button push; for charge (where N is slot 1-6):
+
+- Timed Charge Start Time N
+- Timed Charge End Time N
+- Button Update Charge Time N
+
+And discharge:
+
+- Timed Discharge Start Time N
+- Timed Discharge End Time N
+- Button Update Discharge Time N
+
 
 # Thanks
 Big thanks & kudo's to [@LucidityCrash](https://github.com/LucidityCrash) for all the work on getting the SolisCloud support working!

--- a/custom_components/solis/service.py
+++ b/custom_components/solis/service.py
@@ -30,8 +30,6 @@ from .soliscloud_api import SoliscloudAPI, SoliscloudConfig
 SCHEDULE_OK = 300
 # Attempt retries every 1 minute if we fail to talk to the API, though
 SCHEDULE_NOK = 60
-# If we have controls then update more frequently because they can be changed externtally
-SCHEDULE_CONTROLS = 30
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -284,10 +282,7 @@ class InverterService:
                 if data is not None:
                     # And finally get the inverter details
                     # default to updating after SCHEDULE_OK seconds;
-                    if self.controllable:
-                        update = timedelta(seconds=SCHEDULE_CONTROLS)
-                    else:
-                        update = timedelta(seconds=SCHEDULE_OK)
+                    update = timedelta(seconds=SCHEDULE_OK)
                     # ...but try to figure out a better next-update time based on when the API last received its data
                     try:
                         ts = getattr(data, INVERTER_TIMESTAMP_UPDATE)

--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -761,8 +761,10 @@ class SoliscloudAPI(BaseAPI):
 
     async def _fetch_token(self, username: str, password: str) -> str:
         """
-        Fetch Station Details
+        Fetch CSRF token for station control
         """
+        if password == "":
+          return ""
 
         params = {
             "username": username,

--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -308,12 +308,16 @@ class SoliscloudAPI(BaseAPI):
             else:
                 _LOGGER.debug("Valid inverters: %s", list(self._inverter_list.keys()))
             try:
-                token = await self._fetch_token(self.config.username, self.config._password)
-                self._token = token
-                if token == "":
-                    _LOGGER.info("Failed to acquire CSRF token")
+                if not self.config._password:
+                  _LOGGER.info("No control password set; control mode disabled")
+                  self._token = ""
                 else:
-                    _LOGGER.debug("CSRF token acquired")
+                  token = await self._fetch_token(self.config.username, self.config._password)
+                  self._token = token
+                  if token == "":
+                      _LOGGER.info("Failed to acquire CSRF token")
+                  else:
+                      _LOGGER.debug("CSRF token acquired")
             except:
                 _LOGGER.info("Failed to acquire CSRF token")
 
@@ -763,9 +767,6 @@ class SoliscloudAPI(BaseAPI):
         """
         Fetch CSRF token for station control
         """
-        if password == "":
-          return ""
-
         params = {
             "username": username,
             "password": hashlib.md5(password.encode("utf-8")).hexdigest(),
@@ -779,7 +780,7 @@ class SoliscloudAPI(BaseAPI):
             else:
                 _LOGGER.info(f"({AUTHENTICATE:s} responded with error: {jsondata}")
         else:
-            _LOGGER.info("Unable to fetch authenticate with username and password")
+            _LOGGER.info("Unable to fetch authentication token with username and password")
         return ""
 
     async def write_control_data(self, device_serial: str, cid: str, value: str):


### PR DESCRIPTION
I think this may be the cause of https://github.com/hultenvp/solis-sensor/issues/437; the control code increased frequency of polling to once every minute, instead of once every 5 minutes: [#398 (files)](https://github.com/hultenvp/solis-sensor/pull/398/files?w=1#diff-af00c6075e98805923b96dcf422d2aab2d26713b9326640d5bf345dfaf6b09ecR38-R39).  This PR reverts that change and resets back to polling every 5 minutes.  Let's see if this helps with the issues people have been seeing.

Also: this disables the "control mode" features entirely, if the password is unset or empty, or the "portal_control_api" checkbox is off.

Finally I tidied up the README a bit by moving the Control Mode readme section down a bit lower, instead of right at top.