### PR TITLE
440 - Add inverter on/off control switch and EPM power limit control

### DIFF
--- a/custom_components/solis/control_const.py
+++ b/custom_components/solis/control_const.py
@@ -302,7 +302,7 @@ ALL_CONTROLS = {
                 device_class=NumberDeviceClass.POWER,
                 icon="mdi:transmission-tower-export",
                 native_min_value=0,
-                native_max_value=1000000000, # 1 GW
+                native_max_value=1000000000,  # 1 GW
                 native_step=1,
             )
         ],

--- a/custom_components/solis/control_const.py
+++ b/custom_components/solis/control_const.py
@@ -294,6 +294,18 @@ ALL_CONTROLS = {
                 native_step=1,
             )
         ],
+        "230": [
+            SolisNumberEntityDescription(
+                name="System Export Power Limit Value",
+                key="sytem_export_power_limit_value",
+                native_unit_of_measurement=UnitOfElectricCurrent.WATT,
+                device_class=NumberDeviceClass.POWER,
+                icon="mdi:transmission-tower-export",
+                native_min_value=0,
+                native_max_value=1000000000, # 1 GW
+                native_step=1,
+            )
+        ],
         "636": [
             SolisSelectEntityDescription(
                 name="Energy Storage Control Switch",
@@ -308,6 +320,17 @@ ALL_CONTROLS = {
                     "64": "Feed-In Priority Mode - No Grid Charging",
                     "80": "Feed-In Priority Mode - No Grid Charging, Backup Mode On",
                     "5": "Off-Grid Mode",
+                },
+                icon="mdi:dip-switch",
+            )
+        ],
+        "5161": [
+            SolisSelectEntityDescription(
+                name="Inverter energy export on/off Control Switch",
+                key="inverter_energy_export_on_off_control_switch",
+                option_dict={
+                    "190": "ON",
+                    "222": "OFF",
                 },
                 icon="mdi:dip-switch",
             )

--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -309,15 +309,15 @@ class SoliscloudAPI(BaseAPI):
                 _LOGGER.debug("Valid inverters: %s", list(self._inverter_list.keys()))
             try:
                 if not self.config._password:
-                  _LOGGER.info("No control password set; control mode disabled")
-                  self._token = ""
+                    _LOGGER.info("No control password set; control mode disabled")
+                    self._token = ""
                 else:
-                  token = await self._fetch_token(self.config.username, self.config._password)
-                  self._token = token
-                  if token == "":
-                      _LOGGER.info("Failed to acquire CSRF token")
-                  else:
-                      _LOGGER.debug("CSRF token acquired")
+                    token = await self._fetch_token(self.config.username, self.config._password)
+                    self._token = token
+                    if token == "":
+                        _LOGGER.info("Failed to acquire CSRF token")
+                    else:
+                        _LOGGER.debug("CSRF token acquired")
             except:
                 _LOGGER.info("Failed to acquire CSRF token")
 


### PR DESCRIPTION
PR for issue #440. I've added 2 new controls to turn the inverter on/off and to limit the exported power. This can be used to stop the inverter from exporting power to the grid when the energy prices are negative.

For this to work you need to have a S3-WiFi-ST datalogger or better, older models won't allow you to turn off the inverter.

I've included the data I used to create these 2 new controls below

On/Off switch data from the soliscloud inverter control page:

```{
            "msg": "190",
            "yuanzhi": "190",
            "sysCommand": {
                "id": "5161",
                "createDate": 1656582722000,
                "updateDate": 1740103269000,
                "remarks": "并网,开关",
                "deleteFlag": 0,
                "inverterModelId": "1",
                "widgetType": 5,
                "type": "device_switch",
                "functionCode": 6,
                "registerAddr": 3006,
                "functionCodeRead": 3,
                "registerAddrRead": 3006,
                "registerNumber": 1,
                "value": "1",
                "yzRead": "1107,r_kgjsn",
                "yzWrite": "1107,s_kgjsn",
                "yzRead0505": "1100,r_kgjsn",
                "yzWrite0505": "1100,s_kgjsn",
                "productModel": "1,2101,2102",
                "level": 0,
                "pid": "5163",
                "name1": "逆变器开关",
                "name2": "on/off",
                "name4": "on/off",
                "name6": "on/off",
                "name7": "on/off",
                "name8": "on/off",
                "isJiChu": 2,
                "menu1": "[{\"name\":\"关机\",\"value\":\"222\"},{\"name\":\"开机\",\"value\":\"190\"}]",
                "menu2": "[{\"name\":\"OFF\",\"value\":\"222\"},{\"name\":\"ON\",\"value\":\"190\"}]",
                "menu3": "[{\"name\":\"Apagado\",\"value\":\"222\"},{\"name\":\"Encendido\",\"value\":\"190\"}]",
                "menu5": "[{\"name\":\"Ausschalten\",\"value\":\"222\"},{\"name\":\"Strom einschalten\",\"value\":\"190\"}]",
                "menu9": "[{\"name\":\"Desligado\",\"value\":\"222\"},{\"name\":\"Ligado\",\"value\":\"190\"}]",
                "menu10": "[{\"name\":\"Spegnimento\",\"value\":\"222\"},{\"name\":\"Accensione\",\"value\":\"190\"}]",
                "needRead": 0,
                "bit": -1,
                "unbit": "-1",
                "othersOnbit": "-1",
                "xiaoshu": -1,
                "auth": 0,
                "edit": 0,
                "batchCommand": 0,
                "offSet": -1,
                "isPageShow": 0,
                "isApiShow": 0,
                "dspMin": 0,
                "dspMax": 65535,
                "hmiMin": 0,
                "hmiMax": 65535,
                "buttonShow": 0,
                "phase": 1,
                "buttonControlShow": 0,
                "on": 1,
                "off": 0,
                "passWordCheck": false,
                "passWordCheckType": 0,
                "needRefresh": 0,
                "freshByRules": 0,
                "idStr": "5161"
            },
            "command": "AT+TEST=GIN485:01 03 0b be 00 01 e6 0a",
            "cid": "5161"
        }
```

EPM Power limit data from Soliscloud inverter control page:

```
         {
            "msg": "0",
            "yuanzhi": "0",
            "sysCommand": {
                "id": "230",
                "createDate": 1670227908000,
                "updateDate": 1740618826000,
                "remarks": "系统输出功率限制值",
                "deleteFlag": 0,
                "inverterModelId": "1",
                "widgetType": 3,
                "type": "epm_back_flow_power_in",
                "functionCode": 6,
                "registerAddr": 3151,
                "functionCodeRead": 3,
                "registerAddrRead": 3151,
                "registerNumber": 1,
                "value": "0.01",
                "productModel": "1",
                "level": 1,
                "pid": "9055",
                "name1": "系统输出功率限制值",
                "name2": "System Export Power Limit Value",
                "name3": "Valor límite de potencia de exportación del sistema",
                "name5": "Grenzwert für System-Exportleistung",
                "name9": "Valor limite da potência de exportação do sistema",
                "name10": "Valore limite di potenza di esportazione del sistema",
                "order": 30,
                "isJiChu": 1,
                "needRead": 0,
                "bit": -1,
                "unbit": "-1",
                "othersOnbit": "-1",
                "unit": "W",
                "xiaoshu": -1,
                "auth": 0,
                "edit": 0,
                "batchCommand": 0,
                "offSet": -1,
                "isPageShow": 0,
                "isApiShow": 0,
                "dspMin": 0,
                "dspMax": 65535,
                "hmiMin": 0,
                "hmiMax": 65535,
                "buttonShow": 0,
                "phase": 1,
                "buttonControlShow": 0,
                "on": 1,
                "off": 0,
                "passWordCheck": false,
                "passWordCheckType": 0,
                "needRefresh": 0,
                "freshByRules": 0,
                "idStr": "230"
            },
            "command": "AT+TEST=GIN485:01 03 0c 4e 00 11 e6 81",
            "cid": "230"
        }
```