### PR TITLE
HMI Flag fb00 check should check for value 43605 or higher not just equal to 43605

### DIFF
--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -455,7 +455,7 @@ class SoliscloudAPI(BaseAPI):
                 if jsondata["code"] == "0":
                     try:
                         hmi_flag = jsondata.get("data", {}).get("msg", "")
-                        self._hmi_fb00[device_serial] = hex(int(hmi_flag)) == "0xaa55"
+                        self._hmi_fb00[device_serial] = int(hmi_flag) >= 43605
                         if self._hmi_fb00[device_serial]:
                             _LOGGER.debug(f"HMI firmware version >=4B00 for Inverter SN {device_serial} ")
                         else:


### PR DESCRIPTION
0xaa55 converts to 43605, but I currently have 49857. This results in the following error:
`cid: 103   - /v2/api/atRead responded with error: B0600`

I therefor changed the check for firmware version to actually check if it is equal or higher than 43605 as the debug line below says.

Also there is no need to convert the int value of the hmi flag to hex I think so I removed that.

This fixes: #452