### PR TITLE
Support on/off switch for older HMI versions, the id is 5162 instead of 5161

### DIFF
--- a/custom_components/solis/control_const.py
+++ b/custom_components/solis/control_const.py
@@ -1052,5 +1052,16 @@ ALL_CONTROLS = {
                 icon="mdi:dip-switch",
             )
         ],
+        "5162": [
+            SolisSelectEntityDescription(
+                name="Inverter energy export on/off Control Switch",
+                key="inverter_energy_export_on_off_control_switch",
+                option_dict={
+                    "190": "ON",
+                    "222": "OFF",
+                },
+                icon="mdi:dip-switch",
+            )
+        ],
     },
 }


### PR DESCRIPTION
This fixes the issue described in the comments of #440 