### PR TITLE
Added power limit percentage to both control dicts, 110% is the default value

### DIFF
--- a/custom_components/solis/control_const.py
+++ b/custom_components/solis/control_const.py
@@ -262,6 +262,18 @@ ALL_CONTROLS = {
         #         key="update_timed_charge_discharge",
         #     ),
         # ],
+        "15": [
+            SolisNumberEntityDescription(
+                name="Power limit setting",
+                key="power_limit_setting",
+                native_unit_of_measurement=PERCENTAGE,
+                device_class=NumberDeviceClass.POWER_FACTOR,
+                icon="mdi:transmission-tower-export",
+                native_min_value=0,
+                native_max_value=110,
+                native_step=1,
+            )
+        ],
         "157": [
             SolisNumberEntityDescription(
                 name="Backup SOC",
@@ -850,6 +862,18 @@ ALL_CONTROLS = {
         ],
     },
     False: {
+        "15": [
+            SolisNumberEntityDescription(
+                name="Power limit setting (% of rated power)",
+                key="power_limit_setting",
+                native_unit_of_measurement=PERCENTAGE,
+                device_class=NumberDeviceClass.POWER_FACTOR,
+                icon="mdi:transmission-tower-export",
+                native_min_value=0,
+                native_max_value=110,
+                native_step=1,
+            )
+        ],
         "103": [
             SolisNumberEntityDescription(
                 name="Timed Charge Current 1",


### PR DESCRIPTION
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/3c346fbd-966d-4fc9-a43e-72a291181f48" />

This control controls the amount of power that the inverter will export, setting it to 10% for example will limit the inverter to export 10% of the rated power. My rated power is 4kW so setting it to 10% will limit it to 400W as you can see below:

<img width="471" alt="image" src="https://github.com/user-attachments/assets/2871890e-8b78-4169-86a5-465b31583484" />

