### PR TITLE
Allow integration setup when no inverters are found, with inverter discovery retry if 0 inverters are found.

### DIFF
--- a/custom_components/solis/__init__.py
+++ b/custom_components/solis/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_PASSWORD,
     CONF_PLANT_ID,
     CONF_PORTAL_DOMAIN,
+    CONF_REFRESH_INVERTER_DISCOVERY,
     CONF_REFRESH_NOK,
     CONF_REFRESH_OK,
     CONF_SECRET,
@@ -106,13 +107,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Initialize the Ginlong data service.
     refresh_ok = 300
     refresh_error = 60
+    refresh_inverter_discovery = 300
     try:
         # Fixme: https://github.com/hultenvp/solis-sensor/issues/496
         refresh_ok = config[CONF_REFRESH_OK]
         refresh_error = config[CONF_REFRESH_NOK]
+        refresh_inverter_discovery = config.get(CONF_REFRESH_INVERTER_DISCOVERY, 300)
     except KeyError:
         pass
-    service: InverterService = InverterService(portal_config, hass, refresh_ok, refresh_error)
+    service: InverterService = InverterService(
+        portal_config, hass, refresh_ok, refresh_error, refresh_inverter_discovery
+    )
     hass.data[DOMAIN][entry.entry_id] = service
 
     # Forward the setup to the sensor platform.

--- a/custom_components/solis/__init__.py
+++ b/custom_components/solis/__init__.py
@@ -107,14 +107,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Initialize the Ginlong data service.
     refresh_ok = 300
     refresh_error = 60
-    refresh_inverter_discovery = 300
     try:
         # Fixme: https://github.com/hultenvp/solis-sensor/issues/496
         refresh_ok = config[CONF_REFRESH_OK]
         refresh_error = config[CONF_REFRESH_NOK]
-        refresh_inverter_discovery = config.get(CONF_REFRESH_INVERTER_DISCOVERY, 300)
     except KeyError:
         pass
+
+    refresh_inverter_discovery = 300
+    try:
+        refresh_inverter_discovery = config[CONF_REFRESH_INVERTER_DISCOVERY]
+    except KeyError:
+        pass
+
     service: InverterService = InverterService(
         portal_config, hass, refresh_ok, refresh_error, refresh_inverter_discovery
     )

--- a/custom_components/solis/config_flow.py
+++ b/custom_components/solis/config_flow.py
@@ -191,10 +191,8 @@ class SolisConfigFlow(ConfigFlow, domain=DOMAIN):
                         await self.async_set_unique_id(plant_id)
                         if not api.inverters:
                             _LOGGER.warning(
-                                "No inverters found for plant %s. "
-                                "The integration will be set up, but no "
-                                "sensors will be available until an "
-                                "inverter is connected.",
+                                "No inverters found for plant %s. The integration will be set up, "
+                                "but no sensors will be available until an inverter is connected.",
                                 plant_id,
                             )
                         title = f"Station {api.plant_name}" if api.plant_name else f"Station {plant_id}"

--- a/custom_components/solis/config_flow.py
+++ b/custom_components/solis/config_flow.py
@@ -216,7 +216,7 @@ class SolisConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Schema(
                     {
                         vol.Required(CONF_CONTROL, default=prev_control.get(CONF_CONTROL, False)): bool,
-                        vol.Optional(CONF_PASSWORD, default=prev_control.get(CONF_PASSWORD)): cv.string,
+                        vol.Optional(CONF_PASSWORD, default=prev_control.get(CONF_PASSWORD, "")): cv.string,
                     }
                 ),
                 {"collapsed": False},

--- a/custom_components/solis/config_flow.py
+++ b/custom_components/solis/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_PASSWORD,
     CONF_PLANT_ID,
     CONF_PORTAL_DOMAIN,
+    CONF_REFRESH_INVERTER_DISCOVERY,
     CONF_REFRESH_NOK,
     CONF_REFRESH_OK,
     CONF_SECRET,
@@ -73,7 +74,9 @@ class SolisOptionsFlowHandler(OptionsFlow):
             updated_config[CONF_REFRESH_OK] = user_input.get(
                 CONF_REFRESH_OK, updated_config.get(CONF_REFRESH_OK, 300))
             updated_config[CONF_REFRESH_NOK] = user_input.get(
-                CONF_REFRESH_NOK, updated_config.get(CONF_REFRESH_NOK, 60)
+                CONF_REFRESH_NOK, updated_config.get(CONF_REFRESH_NOK, 60))
+            updated_config[CONF_REFRESH_INVERTER_DISCOVERY] = user_input.get(
+                CONF_REFRESH_INVERTER_DISCOVERY, updated_config.get(CONF_REFRESH_INVERTER_DISCOVERY, 300)
             )
 
             self.hass.config_entries.async_update_entry(
@@ -97,6 +100,8 @@ class SolisOptionsFlowHandler(OptionsFlow):
                 CONF_REFRESH_OK, 300)): cv.positive_int,
             vol.Required(CONF_REFRESH_NOK, default=self.config_entry.data.get(
                 CONF_REFRESH_NOK, 60)): cv.positive_int,
+            vol.Required(CONF_REFRESH_INVERTER_DISCOVERY, default=self.config_entry.data.get(
+                CONF_REFRESH_INVERTER_DISCOVERY, 300)): cv.positive_int,
             vol.Required("Control"): data_entry_flow.section(
                 vol.Schema(
                     {
@@ -184,16 +189,26 @@ class SolisConfigFlow(ConfigFlow, domain=DOMAIN):
                     api = SoliscloudAPI(config)
                     if await api.login(async_get_clientsession(self.hass)):
                         await self.async_set_unique_id(plant_id)
-                        return self.async_create_entry(title=f"Station {api.plant_name}", data=self._data)
+                        if not api.inverters:
+                            _LOGGER.warning(
+                                "No inverters found for plant %s. "
+                                "The integration will be set up, but no "
+                                "sensors will be available until an "
+                                "inverter is connected.",
+                                plant_id,
+                            )
+                        title = f"Station {api.plant_name}" if api.plant_name else f"Station {plant_id}"
+                        return self.async_create_entry(title=title, data=self._data)
                     errors["base"] = "auth"
 
         data_schema = {
             vol.Required(CONF_USERNAME, default=None): cv.string,
-            vol.Required(CONF_KEY_ID, default=""): cv.string,
-            vol.Required(CONF_SECRET, default=""): cv.string,
+            vol.Required(CONF_KEY_ID, default=None): cv.string,
+            vol.Required(CONF_SECRET, default=None): cv.string,
             vol.Required(CONF_PLANT_ID, default=None): cv.string,
             vol.Required(CONF_REFRESH_OK, default=300): cv.positive_int,
             vol.Required(CONF_REFRESH_NOK, default=60): cv.positive_int,
+            vol.Required(CONF_REFRESH_INVERTER_DISCOVERY, default=300): cv.positive_int,
             vol.Required("Control"): data_entry_flow.section(
                 vol.Schema(
                     {

--- a/custom_components/solis/config_flow.py
+++ b/custom_components/solis/config_flow.py
@@ -201,19 +201,22 @@ class SolisConfigFlow(ConfigFlow, domain=DOMAIN):
                         return self.async_create_entry(title=title, data=self._data)
                     errors["base"] = "auth"
 
+        prev = user_input or {}
+        prev_control = prev.get("Control") or {}
         data_schema = {
-            vol.Required(CONF_USERNAME, default=None): cv.string,
-            vol.Required(CONF_KEY_ID, default=None): cv.string,
-            vol.Required(CONF_SECRET, default=None): cv.string,
-            vol.Required(CONF_PLANT_ID, default=None): cv.string,
-            vol.Required(CONF_REFRESH_OK, default=300): cv.positive_int,
-            vol.Required(CONF_REFRESH_NOK, default=60): cv.positive_int,
-            vol.Required(CONF_REFRESH_INVERTER_DISCOVERY, default=300): cv.positive_int,
+            vol.Required(CONF_USERNAME, default=prev.get(CONF_USERNAME)): cv.string,
+            vol.Required(CONF_KEY_ID, default=prev.get(CONF_KEY_ID)): cv.string,
+            vol.Required(CONF_SECRET, default=prev.get(CONF_SECRET)): cv.string,
+            vol.Required(CONF_PLANT_ID, default=prev.get(CONF_PLANT_ID)): cv.string,
+            vol.Required(CONF_REFRESH_OK, default=prev.get(CONF_REFRESH_OK, 300)): cv.positive_int,
+            vol.Required(CONF_REFRESH_NOK, default=prev.get(CONF_REFRESH_NOK, 60)): cv.positive_int,
+            vol.Required(CONF_REFRESH_INVERTER_DISCOVERY, default=prev.get(
+                CONF_REFRESH_INVERTER_DISCOVERY, 300)): cv.positive_int,
             vol.Required("Control"): data_entry_flow.section(
                 vol.Schema(
                     {
-                        vol.Required(CONF_CONTROL, default=False): bool,
-                        vol.Optional(CONF_PASSWORD): cv.string,
+                        vol.Required(CONF_CONTROL, default=prev_control.get(CONF_CONTROL, False)): bool,
+                        vol.Optional(CONF_PASSWORD, default=prev_control.get(CONF_PASSWORD)): cv.string,
                     }
                 ),
                 {"collapsed": False},

--- a/custom_components/solis/const.py
+++ b/custom_components/solis/const.py
@@ -42,6 +42,7 @@ CONF_PLANT_ID = "portal_plant_id"
 CONF_CONTROL = "portal_control_api"
 CONF_REFRESH_OK = "refresh_ok"
 CONF_REFRESH_NOK = "refresh_nok"
+CONF_REFRESH_INVERTER_DISCOVERY = "refresh_inverter_discovery"
 
 DOMAIN = "solis"
 SENSOR_PREFIX = "Solis"

--- a/custom_components/solis/manifest.json
+++ b/custom_components/solis/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "solis",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "config_flow": true,
   "name": "Solis Inverter",
   "iot_class": "cloud_polling",

--- a/custom_components/solis/service.py
+++ b/custom_components/solis/service.py
@@ -77,10 +77,12 @@ class InverterService:
     """Serves all plantId's and inverters on a Ginlong account"""
 
     def __init__(
-        self, portal_config: PortalConfig, hass: HomeAssistant, refresh_ok: int = 300, refresh_nok: int = 60
+        self, portal_config: PortalConfig, hass: HomeAssistant, refresh_ok: int = 300, refresh_nok: int = 60,
+        refresh_inverter_discovery: int = 300,
     ) -> None:
         self._schedule_ok: int = refresh_ok
         self._schedule_nok: int = refresh_nok
+        self._schedule_inverter_discovery: int = refresh_inverter_discovery
         self._last_updated: datetime | None = None
         self._logintime: datetime | None = None
         self._subscriptions: dict[str, dict[str, ServiceSubscriber]] = {}
@@ -280,6 +282,13 @@ class InverterService:
         if await self._login():
             inverters = self._api.inverters
             if inverters is None:
+                return
+            if not inverters:
+                # No inverters found, retry discovery after configured delay
+                _LOGGER.debug("No inverters available, retrying in %s seconds", self._schedule_inverter_discovery)
+                update = timedelta(seconds=self._schedule_inverter_discovery)
+                await self._logout()
+                self.schedule_update(update)
                 return
             for inverter_serial in inverters:
                 data = await self._api.fetch_inverter_data(inverter_serial)

--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -314,6 +314,7 @@ class SoliscloudAPI(BaseAPI):
         self._is_online: bool = False
         self._data: dict[str, str | int | float] = {}
         self._inverter_list: dict[str, str] | None = None
+        self._plant_name: str | None = None
         self._token = ""
         self._hmi_fb00 = {}
 

--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -359,6 +359,9 @@ class SoliscloudAPI(BaseAPI):
         
         if len(self._inverter_list) == 0:
             _LOGGER.warning("No inverters found")
+            station = await self._get_station_details(self.config.plant_id)
+            if station:
+                self._plant_name = station.get("data", {}).get("sno")
         else:
             _LOGGER.debug("Found inverters: %s", list(self._inverter_list.keys()))
             for inv in list(self._inverter_list):

--- a/custom_components/solis/soliscloud_api.py
+++ b/custom_components/solis/soliscloud_api.py
@@ -301,6 +301,10 @@ class SoliscloudConfig(PortalConfig):
         return self._workarounds
 
 
+class SoliscloudApiError(Exception):
+    """Raised when a SolisCloud API call fails."""
+
+
 class SoliscloudAPI(BaseAPI):
     """Class with functions for reading data from the Soliscloud Portal."""
 
@@ -340,14 +344,22 @@ class SoliscloudAPI(BaseAPI):
         await self._config.load_workarounds()
 
         # Request inverter list
-        self._inverter_list = await self.fetch_inverter_list(self.config.plant_id)
+        try:
+            self._inverter_list = await self.fetch_inverter_list(self.config.plant_id)
+        except SoliscloudApiError as err:
+            _LOGGER.warning("Failed to fetch inverter list: %s", err)
+            self._inverter_list = {}
+            self._is_online = False
+            return self._is_online
+
+        # Inverter list request completed without errors. This means authorization was successful
+        _LOGGER.info("Login successful")
+        self._is_online = True
+        
         if len(self._inverter_list) == 0:
             _LOGGER.warning("No inverters found")
-            self._is_online = False
         else:
-            _LOGGER.info("Login successful")
             _LOGGER.debug("Found inverters: %s", list(self._inverter_list.keys()))
-            self._is_online = True
             for inv in list(self._inverter_list):
                 data = await self.fetch_inverter_data(inv)
                 try:
@@ -356,9 +368,7 @@ class SoliscloudAPI(BaseAPI):
                     _LOGGER.info("No access to inverter %s, removing", inv)
                     del self._inverter_list[inv]
             if len(self._inverter_list) == 0:
-                _LOGGER.warning("No valid inverters found, login failed")
-                self._is_online = False
-                return self._is_online
+                _LOGGER.warning("No valid inverters found")
             else:
                 _LOGGER.debug("Valid inverters: %s", list(self._inverter_list.keys()))
             try:
@@ -386,6 +396,8 @@ class SoliscloudAPI(BaseAPI):
     async def fetch_inverter_list(self, plant_id: str) -> dict[str, str]:
         """
         Fetch return list of inverters { inverter serial : device_id }
+
+        Raises SoliscloudApiError on API failure.
         """
 
         device_ids = {}
@@ -396,13 +408,10 @@ class SoliscloudAPI(BaseAPI):
         if result[SUCCESS] is True:
             result_json: dict = result[CONTENT]
             if result_json["code"] != "0":
-                _LOGGER.info(
-                    "%s responded with error: %s:%s",
-                    INVERTER_DETAIL,
-                    result_json["code"],
-                    result_json["msg"],
+                raise SoliscloudApiError(
+                    f"{INVERTER_DETAIL} responded with error: "
+                    f"{result_json['code']}:{result_json['msg']}"
                 )
-                return device_ids
             try:
                 for record in result_json["data"]["page"]["records"]:
                     serial = record.get("sn")
@@ -412,10 +421,13 @@ class SoliscloudAPI(BaseAPI):
                 _LOGGER.debug("Response contains unexpected data: %s", result_json)
         elif result[STATUS_CODE] == 408:
             now = datetime.now().strftime("%d-%m-%Y %H:%M GMT")
-            _LOGGER.warning(
-                "Your system time must be set correctly for this integration \
-            to work, your time is %s",
-                now,
+            raise SoliscloudApiError(
+                "Your system time must be set correctly for this integration "
+                f"to work, your time is {now}"
+            )
+        else:
+            raise SoliscloudApiError(
+                f"Failed to fetch inverter list (status {result[STATUS_CODE]})"
             )
         return device_ids
 

--- a/custom_components/solis/strings.json
+++ b/custom_components/solis/strings.json
@@ -23,7 +23,8 @@
                     "portal_plant_id": "Station ID as found on portal website (see README)",
                     "portal_control_api": "Enable SolisCloud control",
                     "refresh_ok": "Refresh interval in seconds (default 300s)",
-                    "refresh_nok": "Refresh interval in seconds, after an API error (default 60s)"
+                    "refresh_nok": "Refresh interval in seconds, after an API error (default 60s)",
+                    "refresh_inverter_discovery": "Inverter discovery retry interval in seconds (default 300s)"
                 },
                 "sections": {
                     "Control": {
@@ -45,6 +46,7 @@
                 "data": {
                     "refresh_ok": "Refresh interval in seconds (default 300s)",
                     "refresh_nok": "Refresh interval in seconds for errors (default 60s)",
+                    "refresh_inverter_discovery": "Inverter discovery retry interval in seconds (default 300s)",
                     "portal_domain":"PV Portal URL, e.g. https://www.soliscloud.com:13333",
                     "portal_username": "Portal username or email address",
                     "portal_key_id": "API Key ID provided by SolisCloud",

--- a/custom_components/solis/translations/en.json
+++ b/custom_components/solis/translations/en.json
@@ -32,7 +32,8 @@
                     "portal_plant_id": "Station ID as found on portal website (see README)",
                     "portal_control_api": "Enable SolisCloud control",
                     "refresh_ok": "Refresh interval in seconds (default 300s)",
-                    "refresh_nok": "Refresh interval in seconds, after an API error (default 60s)"
+                    "refresh_nok": "Refresh interval in seconds, after an API error (default 60s)",
+                    "refresh_inverter_discovery": "Inverter discovery retry interval in seconds (default 300s)"
                 },
                 "sections": {
                     "Control": {
@@ -54,6 +55,7 @@
                 "data": {
                     "refresh_ok": "Refresh interval in seconds (default 300s)",
                     "refresh_nok": "Refresh interval in seconds for errors (default 60s)",
+                    "refresh_inverter_discovery": "Inverter discovery retry interval in seconds (default 300s)",
                     "portal_domain": "PV Portal version (SolisCloud? Read the README)",
                     "portal_username": "Portal username or email address",
                     "portal_key_id": "API Key ID provided by SolisCloud",


### PR DESCRIPTION
## Summary
  - Separates API failures from empty inverter lists in `login()` / `fetch_inverter_list()`, so valid credentials with 0 inverters no longer show a misleading "Cannot login" error
  - Registers the integration when credentials are valid but no inverters exist, logging a warning instead
  - Fetches the station name from the station detail API when no inverters are available
  - Adds a configurable `refresh_inverter_discovery` interval (default 300s) that retries inverter discovery when the list is empty

  ## Bonus fixes
  - Retains form field values when the config flow displays a validation error, as the whole popup used to completely reset on error
  - Fixes config flow API Key Secret field showing "00" as default value
  - Fixes missing `_plant_name` attribute on `SoliscloudAPI` (not initialized in `__init__`)

  ## Details
  - `fetch_inverter_list()` now raises `SoliscloudApiError` on API failures, and returns an empty dict on success with no records
  - `login()` catches `SoliscloudApiError` → returns `False` (auth error), empty dict → returns `True` (success, no inverters)
  - When no inverters are found, `login()` fetches the station name via `_get_station_details()`
  - `async_update()` detects an empty inverter list, logs out, and schedules a retry after the configured discovery interval
  - New `CONF_REFRESH_INVERTER_DISCOVERY` config option added to both setup and options flows
  - Config flow form defaults now use the previous `user_input` values when re-displaying after an error

  ## Test plan
  I've tested the checked items manually. The unchecked items require a working inverter/datalogger connection to verify, which I don't currently have. The installer hasn't fixed my setup, yet (that's the situation that prompted this fix).

  - [x] Configure integration with valid credentials but no inverters → should succeed with a warning
  - [x] Configure integration with invalid credentials → should still show auth error
  - [ ] With no inverters, verify re-discovery triggers after the configured interval
  - [ ] Connect an inverter and verify it gets picked up on the next discovery cycle
  - [ ] Verify existing setups with inverters are unaffected
  - [x] Trigger a validation error and verify all fields retain their values
  - [x] Verify Secret/Key ID fields no longer show "00" on first load